### PR TITLE
Use rgbif::name_backbone_checklist() in comparison

### DIFF
--- a/src/compare_to_backbone_and_eu_list.R
+++ b/src/compare_to_backbone_and_eu_list.R
@@ -10,32 +10,27 @@ easin_taxa <- readr::read_csv(
 
 # Create scientific name column based on columns `Name` and `Authorship`
 easin_taxa <- easin_taxa %>%
-  # Add prefix `easin_` to columns to avoid possible name clashes later
-  dplyr::rename_with(~ paste0("easin_", .x)) %>%
-  dplyr::mutate(easin_scientific_name = paste(easin_Name, easin_Authorship)) %>%
+  dplyr::mutate(scientificName = paste(Name, Authorship)) %>%
   # Remove trailing spaces
   dplyr::mutate(
-    easin_scientific_name = stringr::str_trim(easin_scientific_name)
+    scientificName = stringr::str_trim(scientificName)
 )
 
-# Match to GBIF Backbone
-easin_taxa_match <- purrr::map(
-  easin_taxa$easin_scientific_name,
-  rgbif::name_backbone,
-  strict = TRUE,
-  .progress = TRUE
+# Check taxa against GBIF Backbone
+easin_taxa <- rgbif::name_backbone_checklist(
+  name = easin_taxa,
+  strict = TRUE
   ) %>%
-  purrr::list_rbind()
-
-# Add `gbif_` prefix to matched columns to make provenance clear
-easin_taxa_match <- easin_taxa_match %>%
-  dplyr::rename_with(~ paste0("gbif_", .x))
-
-# Join EASIN taxa names to matched results
-easin_taxa <- dplyr::bind_cols(
-  easin_taxa,
-  easin_taxa_match
-)
+  # Rename the original columns, returned with prefix `verbatim`, using suffix `easin_`
+  dplyr::rename_with(
+    .cols = dplyr::starts_with("verbatim"),
+    .fn = ~ stringr::str_replace(.x, pattern = "verbatim", replacement = "easin")
+  ) %>%
+  # Add prefix `gbif_` to all other columns
+  dplyr::rename_with(
+    .cols = -dplyr::starts_with("easin"),
+    .fn = ~ paste0("gbif_", .x)
+  )
 
 # Get taxa matching strictly, i.e. no higher rank or fuzzy matches
 easin_taxa_matched_backbone <- easin_taxa %>%

--- a/src/compare_to_backbone_and_eu_list.R
+++ b/src/compare_to_backbone_and_eu_list.R
@@ -21,7 +21,7 @@ easin_taxa <- rgbif::name_backbone_checklist(
   name = easin_taxa,
   strict = TRUE
   ) %>%
-  # Rename the original columns, returned with prefix `verbatim`, using suffix `easin_`
+  # Rename the original columns, returned with prefix `verbatim`, using prefix `easin_`
   dplyr::rename_with(
     .cols = dplyr::starts_with("verbatim"),
     .fn = ~ stringr::str_replace(.x, pattern = "verbatim", replacement = "easin")

--- a/src/compare_to_backbone_and_eu_list.R
+++ b/src/compare_to_backbone_and_eu_list.R
@@ -24,7 +24,7 @@ easin_taxa <- rgbif::name_backbone_checklist(
   # Rename the original columns, returned with prefix `verbatim`, using prefix `easin_`
   dplyr::rename_with(
     .cols = dplyr::starts_with("verbatim"),
-    .fn = ~ stringr::str_replace(.x, pattern = "verbatim", replacement = "easin")
+    .fn = ~ stringr::str_replace(.x, pattern = "^verbatim", replacement = "easin")
   ) %>%
   # Add prefix `gbif_` to all other columns
   dplyr::rename_with(

--- a/src/compare_to_backbone_and_eu_list.R
+++ b/src/compare_to_backbone_and_eu_list.R
@@ -21,7 +21,7 @@ easin_taxa <- rgbif::name_backbone_checklist(
   name = easin_taxa,
   strict = TRUE
   ) %>%
-  # Rename the original columns, returned with prefix `verbatim`, using prefix `easin_`
+  # Rename the original columns, returned with prefix `verbatim`, using prefix `easin`
   dplyr::rename_with(
     .cols = dplyr::starts_with("verbatim"),
     .fn = ~ stringr::str_replace(.x, pattern = "^verbatim", replacement = "easin")


### PR DESCRIPTION
This pull request refactors how EASIN taxa are matched against the GBIF Backbone. The main improvement is a switch to a more efficient matching function: `rgbif::name_backbone_checklist()`. Notice that this function contained a bug: I reported it in issue https://github.com/ropensci/rgbif/issues/815 and thanks to that, the function is now working properly and so can be used in our comparison workflow. The power of open science 💪 

**IMPORTANT**: update rgbif to v3.8.4 by installing it as usual, `install.packages("rgbif")`.